### PR TITLE
Add living room lamps

### DIFF
--- a/automation/smoke_alarms.yaml
+++ b/automation/smoke_alarms.yaml
@@ -82,10 +82,11 @@
     service: light.turn_on
     data:
       entity_id:
+        - light.hue_color_lamp_1
         - light.hue_white_lamp_1
         - light.hue_white_lamp_3
-        - light.hue_color_lamp_1
-        - switch.jasco_products_46201_in_wall_smart_switch_switch
         - light.zooz_unknown_type_a000_id_a008_level
         - light.zooz_unknown_type_a000_id_a008_level_2
+        - switch.living_room_bookshelf_lamps
+        - switch.jasco_products_46201_in_wall_smart_switch_switch
 

--- a/automation/switches.yaml
+++ b/automation/switches.yaml
@@ -44,6 +44,7 @@
 
 - alias: Turn On Both Living Room Bookshelf Lamps From Single Switch
   id: turn_on_both_living_room_bookshelf_lamps_from_single_switch
+  # yamllint disable-line rule:line-length
   description: Physically toggling the one reachable switch should toggle the other switch in tandem
   trigger:
     - platform: state

--- a/automation/switches.yaml
+++ b/automation/switches.yaml
@@ -1,6 +1,6 @@
 ---
 - alias: Turn Off Air Purifier Weekdays (6:45am)
-  id: "turn_off_air_purifier_weekdays"
+  id: turn_off_air_purifier_weekdays
   trigger:
     platform: time
     at: "06:45:00"
@@ -18,7 +18,7 @@
       entity_id: switch.wemo_mini_1
 
 - alias: Turn Off Air Purifier Weekends (7:15am)
-  id: "turn_off_air_purifier_weekends"
+  id: turn_off_air_purifier_weekends
   trigger:
     platform: time
     at: "07:15:00"
@@ -33,7 +33,7 @@
       entity_id: switch.wemo_mini_1
 
 - alias: Turn On Air Purifier Mid-Morning
-  id: "turn_on_air_purifier_midmorning"
+  id: turn_on_air_purifier_midmorning
   trigger:
     platform: time
     at: "09:00:00"
@@ -41,4 +41,15 @@
     service: switch.turn_on
     data:
       entity_id: switch.wemo_mini_1
+
+- alias: Turn On Both Living Room Bookshelf Lamps From Single Switch
+  id: turn_on_both_living_room_bookshelf_lamps_from_single_switch
+  description: Physically toggling the one reachable switch should toggle the other switch in tandem
+  trigger:
+    - platform: state
+      entity_id: switch.tp_link_smart_plug_d6d2
+  action:
+    - service: "switch.turn_{{ trigger.to_state.state }}"
+      target:
+        entity_id: switch.tp_link_smart_plug_ac23
 

--- a/components/packages/switch.yaml
+++ b/components/packages/switch.yaml
@@ -1,0 +1,26 @@
+---
+# https://www.home-assistant.io/integrations/switch.template/
+
+switch:
+  - platform: template
+    switches:
+      living_room_bookshelf_lamps:
+        unique_id: switch_living_room_bookshelf_lamps
+        friendly_name: Living Room Bookshelf Lamps
+        icon_template: mdi:lamps
+        value_template: "{{ is_state('switch.tp_link_smart_plug_ac23', 'on') }}"
+        turn_on:
+          - service: switch.turn_on
+            target:
+              entity_id: switch.tp_link_smart_plug_ac23
+          - service: switch.turn_on
+            target:
+              entity_id: switch.tp_link_smart_plug_d6d2
+        turn_off:
+          - service: switch.turn_off
+            target:
+              entity_id: switch.tp_link_smart_plug_ac23
+          - service: switch.turn_off
+            target:
+              entity_id: switch.tp_link_smart_plug_d6d2
+

--- a/lovelace/views/home.yaml
+++ b/lovelace/views/home.yaml
@@ -12,6 +12,7 @@ cards:
       - entity: light.controller_rgb_44_key_ir_cde6d9
       - entity: switch.wemo_mini_1_2
       - entity: switch.jasco_products_46201_in_wall_smart_switch_switch
+      - entity: switch.living_room_bookshelf_lamps
       - entity: light.zooz_unknown_type_a000_id_a008_level
       - entity: light.zooz_unknown_type_a000_id_a008_level_2
       - entity: switch.wemo_mini_4


### PR DESCRIPTION
Two distinct dumb lamps plugged into two distinct smart switches. Looking for a single reference point in Home Assistant so that a single toggle can be used to turn on/off both lamps.

When the physical button on the switch is toggled to turn one lamp on or off, there should be an automation so that the other switch's state is matched. Since one of the switches is inaccessible because it's behind the bookshelf, only one of the switches will act as the main one.