### PR TITLE
Christmas 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Runs on a [Raspberry Pi 3B](https://www.raspberrypi.org/products/raspberry-pi-3-
 
 # Automations
 
-Christmas lights automations aren't available year-round (they're added when the tree goes up, removed again when the tree goes down). See previous years in [#15](https://github.com/tetsuo13/home-assistant-config/pull/15) and [c013a7c](https://github.com/tetsuo13/home-assistant-config/commit/c013a7c10aa19f6366598c1a0cd125f82ec8b465) on what was done.
+Christmas lights automations aren't available year-round (they're added when the tree goes up, removed again when the tree goes down). See previous years in [#40](https://github.com/tetsuo13/home-assistant-config/pull/40), [#15](https://github.com/tetsuo13/home-assistant-config/pull/15) and [c013a7c](https://github.com/tetsuo13/home-assistant-config/commit/c013a7c10aa19f6366598c1a0cd125f82ec8b465) on what was done.
 
 ## [Door Automations](automation/doors.yaml)
 

--- a/automation/christmas.yaml
+++ b/automation/christmas.yaml
@@ -22,7 +22,7 @@
     service: switch.turn_off
     data:
       entity_id:
-        - switch.366
+        - switch.tp_link_smart_plug_ac7b
         - group.christmas_stars
         - switch.tp_link_smart_plug_ad70
 

--- a/automation/christmas.yaml
+++ b/automation/christmas.yaml
@@ -1,7 +1,7 @@
 ---
 
 - alias: Christmas - Turn On Lights at Sunset
-  id: christmas_turn_on_lights_at_sunset 
+  id: christmas_turn_on_lights_at_sunset
   trigger:
     platform: sun
     event: sunset

--- a/automation/christmas.yaml
+++ b/automation/christmas.yaml
@@ -1,0 +1,28 @@
+---
+
+- alias: Christmas - Turn On Lights at Sunset
+  id: christmas_turn_on_lights_at_sunset 
+  trigger:
+    platform: sun
+    event: sunset
+  action:
+    service: switch.turn_on
+    data:
+      entity_id:
+        - switch.tp_link_smart_plug_ac7b
+        - group.christmas_stars
+        - switch.tp_link_smart_plug_ad70
+
+- alias: Christmas - Turn Off Lights Late at Night
+  id: christmas_turn_off_lights_late_at_night
+  trigger:
+    platform: time
+    at: "23:22:33"
+  action:
+    service: switch.turn_off
+    data:
+      entity_id:
+        - switch.366
+        - group.christmas_stars
+        - switch.tp_link_smart_plug_ad70
+

--- a/components/packages/group.yaml
+++ b/components/packages/group.yaml
@@ -17,3 +17,10 @@ group:
       - media_player.sonos02
       - media_player.sonos04
 
+  christmas_stars:
+    name: Stars in Windows
+    entities:
+      - switch.418
+      - switch.672
+      - switch.wemo_mini_3
+

--- a/components/packages/wemo.yaml
+++ b/components/packages/wemo.yaml
@@ -6,4 +6,5 @@ wemo:
     - !secret wemo_1_ip
     - !secret wemo_2_ip
     - !secret wemo_4_ip
+    - !secret wemo_5_ip
 

--- a/components/packages/wemo.yaml
+++ b/components/packages/wemo.yaml
@@ -5,6 +5,9 @@ wemo:
   static:
     - !secret wemo_1_ip
     - !secret wemo_2_ip
+    - !secret wemo_3_ip
     - !secret wemo_4_ip
     - !secret wemo_5_ip
+    - !secret wemo_6_ip
+    - !secret wemo_7_ip
 

--- a/customize/christmas.yaml
+++ b/customize/christmas.yaml
@@ -2,3 +2,19 @@ switch.366:
   friendly_name: Mantelpiece
   icon: mdi:fireplace-off
 
+switch.418:
+  friendly_name: Bedroom 2 Star
+  icon: mdi:star
+
+switch.672:
+  friendly_name: Bedroom 3 Star
+  icon: mdi:star
+
+switch.wemo_mini_3:
+  friendly_name: Dining Room Star
+  icon: mdi:star
+
+group.christmas_stars:
+  friendly_name: Stars in Windows
+  icon: mdi:star
+

--- a/customize/christmas.yaml
+++ b/customize/christmas.yaml
@@ -1,0 +1,4 @@
+switch.366:
+  friendly_name: Mantelpiece
+  icon: mdi:fireplace-off
+

--- a/customize/christmas.yaml
+++ b/customize/christmas.yaml
@@ -1,4 +1,4 @@
-switch.366:
+switch.tp_link_smart_plug_ac7b:
   friendly_name: Mantelpiece
   icon: mdi:fireplace-off
 
@@ -17,4 +17,8 @@ switch.wemo_mini_3:
 group.christmas_stars:
   friendly_name: Stars in Windows
   icon: mdi:star
+
+switch.tp_link_smart_plug_ad70:
+  friendly_name: Christmas Tree
+  icon: mdi:pine-tree
 

--- a/customize/christmas.yaml
+++ b/customize/christmas.yaml
@@ -1,3 +1,5 @@
+---
+
 switch.tp_link_smart_plug_ac7b:
   friendly_name: Mantelpiece
   icon: mdi:fireplace-off

--- a/lovelace/views/home.yaml
+++ b/lovelace/views/home.yaml
@@ -27,8 +27,9 @@ cards:
     title: Christmas Center
     state_color: true
     entities:
-      - switch.366
+      - switch.tp_link_smart_plug_ac7b
       - group.christmas_stars
+      - switch.tp_link_smart_plug_ad70
   - type: grid
     columns: 2
     square: false

--- a/lovelace/views/home.yaml
+++ b/lovelace/views/home.yaml
@@ -28,6 +28,7 @@ cards:
     state_color: true
     entities:
       - switch.366
+      - group.christmas_stars
   - type: grid
     columns: 2
     square: false

--- a/lovelace/views/home.yaml
+++ b/lovelace/views/home.yaml
@@ -23,6 +23,11 @@ cards:
     states:
       - arm_home
       - arm_away
+  - type: entities
+    title: Christmas Center
+    state_color: true
+    entities:
+      - switch.366
   - type: grid
     columns: 2
     square: false

--- a/secrets.yaml.dist
+++ b/secrets.yaml.dist
@@ -23,6 +23,7 @@ trusted_proxy: 192.168.1.1
 wemo_1_ip: 192.168.1.1
 wemo_2_ip: 192.168.1.1
 wemo_4_ip: 192.168.1.1
+wemo_5_ip: 192.168.1.1
 
 smtp_server: smtp.example.com
 smtp_port: 587

--- a/secrets.yaml.dist
+++ b/secrets.yaml.dist
@@ -22,8 +22,11 @@ trusted_proxy: 192.168.1.1
 
 wemo_1_ip: 192.168.1.1
 wemo_2_ip: 192.168.1.1
+wemo_3_ip: 192.168.1.1
 wemo_4_ip: 192.168.1.1
 wemo_5_ip: 192.168.1.1
+wemo_6_ip: 192.168.1.1
+wemo_7_ip: 192.168.1.1
 
 smtp_server: smtp.example.com
 smtp_port: 587


### PR DESCRIPTION
Changes around Christmas 2023 so that they can be easily removed and also easily referenced in the future. There is no intention of merging this PR.

Lessons learned from previous year:

- Using a group for the window lights makes life easier for both automations (only have to toggle a single switch) and dashboard (again, single switch toggles all lights manually).
- Belkin WeMo WSP080 switches have become unreliable and will periodically disappear from the network. Will show as "unavailable" in Home Assistant and require physically reseating the device to restart. Have had to babysit the two devices on a daily basis used in the window star automations. The third star is a Belkin WeMo F7C063 that has been solid.