### PR TITLE
Binary sensor deprecated because it's been replaced

### DIFF
--- a/automation/alarm.yaml
+++ b/automation/alarm.yaml
@@ -23,12 +23,12 @@
   id: alarm_away_door_alarm
   triggers:
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
+      entity_id: binary_sensor.z_wave_door_window_sensor_open
       to: "on"
       variables:
         location_name: Kitchen
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_2
       to: "on"
       variables:
         location_name: Front
@@ -38,7 +38,7 @@
       variables:
         location_name: Laundry
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_4
       to: "on"
       variables:
         location_name: Office

--- a/automation/doors.yaml
+++ b/automation/doors.yaml
@@ -4,12 +4,12 @@
   id: announce_door_opened
   triggers:
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
+      entity_id: binary_sensor.z_wave_door_window_sensor_open
       to: "on"
       variables:
         location_name: Kitchen
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_2
       to: "on"
       variables:
         location_name: Front
@@ -19,7 +19,7 @@
       variables:
         location_name: Laundry
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_4
       to: "on"
       variables:
         location_name: Office
@@ -47,12 +47,12 @@
   id: announce_door_closed
   triggers:
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
+      entity_id: binary_sensor.z_wave_door_window_sensor_open
       to: "off"
       variables:
         location_name: Kitchen
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_2
       to: "off"
       variables:
         location_name: Front
@@ -62,7 +62,7 @@
       variables:
         location_name: Laundry
     - trigger: state
-      entity_id: binary_sensor.z_wave_door_window_sensor_window_door_is_open
+      entity_id: binary_sensor.z_wave_door_window_sensor_open_4
       to: "off"
       variables:
         location_name: Office
@@ -91,9 +91,9 @@
   triggers:
     trigger: state
     entity_id:
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
+      - binary_sensor.z_wave_door_window_sensor_open_4
+      - binary_sensor.z_wave_door_window_sensor_open_2
+      - binary_sensor.z_wave_door_window_sensor_open
       - binary_sensor.z_wave_door_window_sensor_access_control_window_door_is_open_5
     to: "on"
   mode: queued
@@ -141,9 +141,9 @@
   triggers:
     trigger: state
     entity_id:
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
-      - binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
+      - binary_sensor.z_wave_door_window_sensor_open_4
+      - binary_sensor.z_wave_door_window_sensor_open_2
+      - binary_sensor.z_wave_door_window_sensor_open
       - binary_sensor.z_wave_door_window_sensor_access_control_window_door_is_open_5
     to: "off"
   mode: queued

--- a/customize/sensors.yaml
+++ b/customize/sensors.yaml
@@ -27,11 +27,11 @@ binary_sensor.flood_sensor_water_leak_state:
 binary_sensor.flood_sensor_low_battery_level:
   friendly_name: Laundry Flood Sensor Battery Level
 
-binary_sensor.z_wave_door_window_sensor_window_door_is_open:
+binary_sensor.z_wave_door_window_sensor_open_4:
   friendly_name: Office Door
   device_class: door
 
-binary_sensor.z_wave_door_window_sensor_window_door_is_open_3:
+binary_sensor.z_wave_door_window_sensor_open:
   friendly_name: Kitchen Door
   device_class: door
 
@@ -39,7 +39,7 @@ binary_sensor.z_wave_door_window_sensor_window_door_is_open_5:
   friendly_name: Laundry Door
   device_class: door
 
-binary_sensor.z_wave_door_window_sensor_window_door_is_open_7:
+binary_sensor.z_wave_door_window_sensor_open_2:
   friendly_name: Front Door
   device_class: door
 

--- a/lovelace/views/home.yaml
+++ b/lovelace/views/home.yaml
@@ -71,9 +71,9 @@ cards:
       - entity: binary_sensor.master_bedroom_occupancy
       - entity: binary_sensor.4_in_1_sensor_motion_detection
       - entity: binary_sensor.flood_sensor_water_leak_state
-      - entity: binary_sensor.z_wave_door_window_sensor_window_door_is_open
-      - entity: binary_sensor.z_wave_door_window_sensor_window_door_is_open_3
-      - entity: binary_sensor.z_wave_door_window_sensor_window_door_is_open_7
+      - entity: binary_sensor.z_wave_door_window_sensor_open_4
+      - entity: binary_sensor.z_wave_door_window_sensor_open
+      - entity: binary_sensor.z_wave_door_window_sensor_open_2
       - entity: binary_sensor.z_wave_door_window_sensor_window_door_is_open_5
     state_color: true
 


### PR DESCRIPTION
The binary sensor `binary_sensor.z_wave_door_window_sensor_window_door_is_open_3` is deprecated because it has been replaced with the binary sensor `binary_sensor.z_wave_door_window_sensor_open`.